### PR TITLE
Fix: guard linked_action_itemtype for GLPI 11 compatibility

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -328,11 +328,13 @@ function plugin_accounts_install()
                 $DB->update('glpi_logs', ['itemtype' => $new_itemtype], ['itemtype' => $old_itemtype]);
             }
         }
-        $DB->update(
-            'glpi_logs',
-            ['linked_action_itemtype' => Account::class],
-            ['linked_action_itemtype' => 'PluginAccountsAccount']
-        );
+        if ($DB->fieldExists('glpi_logs', 'linked_action_itemtype')) {
+            $DB->update(
+                'glpi_logs',
+                ['linked_action_itemtype' => Account::class],
+                ['linked_action_itemtype' => 'PluginAccountsAccount']
+            );
+        }
     }
 
     CronTask::Register(Account::class, 'AccountsAlert', DAY_TIMESTAMP);


### PR DESCRIPTION
## Summary

Wraps the `linked_action_itemtype` column update in `$DB->fieldExists()` check during plugin installation/upgrade. This column was removed in GLPI 11, causing a fatal SQL error when installing or upgrading the accounts plugin on GLPI 11.x.

## Changes

- `hook.php`: Added `$DB->fieldExists('glpi_logs', 'linked_action_itemtype')` guard around the `$DB->update()` call that migrates old itemtype references

## Test Plan

- [ ] Install accounts plugin on GLPI 11.x from scratch (no prior data)
- [ ] Upgrade accounts plugin from 3.0.x to 3.2.x on GLPI 11.x
- [ ] Verify plugin still works correctly on GLPI 10.x (column exists, migration runs normally)