### PR TITLE
Fix hash auto-selection when creating new accounts

### DIFF
--- a/src/Account.php
+++ b/src/Account.php
@@ -590,7 +590,17 @@ class Account extends CommonDBTM
                 }
             }
 
-            $hashclass->getFromDBByCrit(['id' => $this->fields["plugin_accounts_hashes_id"]]);
+            // Auto-select the only available hash for new items, so users
+            // don't have to manually pick the fingerprint + encryption key
+            // every time they create an account (regression from 3.0.x).
+            $selected_hash_id = $this->fields["plugin_accounts_hashes_id"];
+            if (empty($selected_hash_id) && count($hashes) === 1) {
+                $only_hash = reset($hashes);
+                $selected_hash_id = $only_hash['id'];
+                $this->fields["plugin_accounts_hashes_id"] = $selected_hash_id;
+            }
+
+            $hashclass->getFromDBByCrit(['id' => $selected_hash_id]);
             if (count($hashclass->fields) > 0) {
                 $hash = $hashclass->fields["hash"];
             } else {
@@ -608,7 +618,7 @@ class Account extends CommonDBTM
         }
 
         $aeskey = new AesKey();
-        if ($aeskey->getFromDBByCrit(['plugin_accounts_hashes_id' => $this->fields["plugin_accounts_hashes_id"]])
+        if ($aeskey->getFromDBByCrit(['plugin_accounts_hashes_id' => $selected_hash_id])
             && $aeskey->fields["name"]) {
             $aeskey_uncrypted = $aeskey->fields["name"];
         }


### PR DESCRIPTION
## Summary

When only one fingerprint (hash) exists for the entity, the plugin now auto-selects it for new accounts. This restores the behavior from version 3.0.x where users didn't have to manually pick the fingerprint and type the encryption key every time they created an account.

## Root Cause

The regression was introduced during the Twig template migration (v3.2.0). The dropdown value comes from `item.fields["plugin_accounts_hashes_id"]` which is `0` for new items, causing the `AesKey` lookup to fail and forcing manual input even when there's only one hash configured.

## Changes

- `src/Account.php` (`showForm`): When creating a new account and exactly one hash exists for the entity, auto-select it and pre-populate the encryption key (if saved as AesKey)

## Test Plan

1. Configure a single fingerprint + encryption key for an entity
2. Save the encryption key via the "Save the encryption key" tab
3. Create a new account in that entity
4. **Before fix**: Hash dropdown is empty, encryption key field requires manual input
5. **After fix**: Hash is auto-selected, encryption key is pre-filled, password auto-decrypts

Fixes #132